### PR TITLE
Add FrameCoach to Camera / On-Set Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated list of software, services, and resources to create videos.
 - [Storyboard / Animatic](#storyboard--animatic)
   - [Apps](#apps)
   - [SaaS](#saas)
+- [Camera / On-Set Tools](#camera--on-set-tools)
 - [Image Editing](#image-editing)
 - [Animations](#animations)
 - [Audio](#audio)
@@ -56,6 +57,13 @@ A curated list of software, services, and resources to create videos.
 
 [Bloober]: https://blooper.ai
 [Boords]: https://boords.com
+
+
+## Camera / On-Set Tools
+
+- [FrameCoach] - Real-time camera coaching app for filmmakers — coaches you through camera settings, composition, and shot choices on set.
+
+[FrameCoach]: https://framecoach.io
 
 
 ## Image Editing


### PR DESCRIPTION
## Summary

- Adds [FrameCoach](https://framecoach.io) — a real-time camera coaching app for filmmakers that helps with camera settings, composition, and shot choices on set.
- Creates a new **Camera / On-Set Tools** section for tools used during the production/filming phase, positioned between Storyboard/Animatic (pre-production) and Image Editing (post-production) to follow the natural video production workflow.

## Why this belongs here

This list covers the full video production pipeline (screenwriting, storyboarding, editing, etc.) but currently lacks a section for on-set/camera tools. FrameCoach fills this gap as a production-phase tool that coaches filmmakers through camera decisions in real time.

## Format

Follows the existing reference-link style used throughout the README.