### PR TITLE
Add RemotionUI to CLI / Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Game engines can be used as well:
 - [Jumpcutter] - Automatically edits videos.
 - [LosslessCut] - The swiss army knife of lossless video/audio editing
 - [MoviePy] - Python library for video editing.
+- [RemotionUI] - Production-ready motion for Remotion. Source you own.
 - [Revideo] - Open source framework for programmatic video editing.
 - [RobustVideoMatting] - Robust video matting in PyTorch.
 - [VapourSynth] - App, plugin, and library for video manipulation.
@@ -259,6 +260,7 @@ Game engines can be used as well:
 [Jumpcutter]: https://github.com/carykh/jumpcutter
 [LosslessCut]: https://github.com/mifi/lossless-cut
 [MoviePy]: https://github.com/Zulko/moviepy
+[RemotionUI]: https://remotionui.com
 [Revideo]: https://github.com/redotvideo/revideo
 [RobustVideoMatting]: https://github.com/PeterL1n/RobustVideoMatting
 [VapourSynth]: https://www.vapoursynth.com/


### PR DESCRIPTION
## Summary
Adds [RemotionUI](https://remotionui.com) to the **CLI / Code** section, alphabetically between MoviePy and Revideo.

Remotion is already listed under Video Editing. RemotionUI is the ecosystem layer — production-ready motion for Remotion, with a registry CLI (`npx remotion-ui add`) that installs components as source you own.

## Entry
```markdown
- [RemotionUI] - Production-ready motion for Remotion. Source you own.
```

## Links
- Docs: https://remotionui.com
- Repo: https://github.com/riaz37/remotion-ui
- npm: https://www.npmjs.com/package/remotion-ui