### PR TITLE
Add Superhighway Media & Entertainment Research Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,5 +341,7 @@ Game engines can be used as well:
 ## Research
 
 - [FilmAgent] - Multi-agent framework for end-to-end film automation in virtual 3D spaces.
+- [Media & Entertainment Research Agent] - Python agent that researches the media and entertainment industry using live web data — box office, streaming viewership, content deals, and audience demographics — into a structured JSON briefing.
 
 [FilmAgent]: https://filmagent.github.io/
+[Media & Entertainment Research Agent]: https://superhighway.walls.sh/guides/media-research-agent


### PR DESCRIPTION
Adds the [Media & Entertainment Research Agent](https://superhighway.walls.sh/guides/media-research-agent) from Superhighway.

**What it does:** A Python agent that researches the media and entertainment industry using live web data — combining trade publication coverage (Variety, Deadline, Hollywood Reporter) with market analytics (Nielsen, Parrot Analytics, Bloomberg), box office data, streaming viewership, content deals, and audience demographics into a structured JSON briefing covering distribution landscape, content economics, IP value, and competitive positioning.

**Endpoints used:** `/research` (industry synthesis) + `/search` (two angles: trade coverage + market data) + `/scrape` (deal reports, Box Office Mojo pages) + `/news` (acquisitions, greenlights, subscriber data) → LLM (structured JSON output).

**Audience:** Content strategists, streaming analysts, entertainment investors, talent agencies, production companies, IP licensing teams.

**Superhighway API:** Pay-per-call web search for AI agents. Free API key at https://superhighway.walls.sh or pay with USDC via x402 (no signup). MCP server: `npx -y superhighway-mcp`.